### PR TITLE
Add Git mirror utility with Gitolite integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,45 @@
 # super-octo-eureka
-Git repo mirroring command line utility
+
+Git repo mirroring command line utility.
+
+## Features
+
+- Mirror-clone repositories into a GitHub-like directory tree using `git clone --mirror`.
+- Update all mirrored repositories with a single command.
+- Integrate with Gitolite by adding and syncing mirror entries in `gitolite-admin`.
+
+## Usage
+
+Run the commands via the module:
+
+```bash
+python -m git_mirror.cli --help
+```
+
+To mirror a repository:
+
+```bash
+python -m git_mirror.cli clone https://github.com/psf/requests.git --base-dir /srv/git
+```
+
+To update all mirrors:
+
+```bash
+python -m git_mirror.cli update-all --base-dir /srv/git
+```
+
+To add the mirror to Gitolite:
+
+```bash
+python -m git_mirror.cli gitolite-add https://github.com/psf/requests.git \
+  --admin-url git@yourhost:gitolite-admin \
+  --admin-dir /home/git/gitolite-admin
+```
+
+To ensure the Gitolite configuration matches on-disk mirrors:
+
+```bash
+python -m git_mirror.cli gitolite-sync --base-dir /srv/git \
+  --admin-url git@yourhost:gitolite-admin \
+  --admin-dir /home/git/gitolite-admin
+```

--- a/git_mirror/__init__.py
+++ b/git_mirror/__init__.py
@@ -1,0 +1,21 @@
+from .core import (
+    RepoID,
+    parse_repo_id,
+    ensure_mirror,
+    iter_mirrored_repos,
+    fetch_mirror,
+    fetch_all,
+)
+
+from .gitolite import (
+    ensure_admin_repo,
+    ensure_include_of_mirrors_conf,
+    upsert_mirror_repo,
+    commit_and_push,
+    add_url_to_gitolite,
+    gitolite_path_for,
+    parse_mirrors_conf,
+    configured_mirror_paths,
+    gitolite_path_from_mirror_dir,
+    sync_gitolite_from_disk,
+)

--- a/git_mirror/cli.py
+++ b/git_mirror/cli.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+CLI for git_mirror.
+
+Commands:
+  clone  <url> --base-dir /path      Mirror-clone (or update) a single repo
+  update-all --base-dir /path        Fetch all mirrors under base-dir
+  list       --base-dir /path        List detected mirrors
+  gitolite-add <url> ...             Add a mirror to gitolite config
+  gitolite-sync --base-dir ...       Sync gitolite config with on-disk mirrors
+
+Examples:
+  git-mirror clone https://github.com/psf/requests.git --base-dir /srv/git
+  git-mirror update-all --base-dir /srv/git
+"""
+
+from __future__ import annotations
+import argparse
+from pathlib import Path
+
+from .core import ensure_mirror, fetch_all, iter_mirrored_repos
+from .gitolite import add_url_to_gitolite, sync_gitolite_from_disk
+
+
+def cmd_clone(args: argparse.Namespace) -> int:
+    target = ensure_mirror(args.url, Path(args.base_dir))
+    print(str(target))
+    return 0
+
+
+def cmd_update_all(args: argparse.Namespace) -> int:
+    results = fetch_all(Path(args.base_dir))
+    failed = [r for r in results if r[1]]
+    for repo, err in results:
+        if err:
+            print(f"[FAIL] {repo} :: {err}")
+        else:
+            print(f"[OK]   {repo}")
+    return 1 if failed else 0
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    base = Path(args.base_dir)
+    for repo in iter_mirrored_repos(base):
+        print(str(repo))
+    return 0
+
+
+def cmd_gitolite_add(args: argparse.Namespace) -> int:
+    res = add_url_to_gitolite(
+        url=args.url,
+        admin_url=args.admin_url,
+        admin_dir=Path(args.admin_dir),
+        readers=args.readers,
+        prefix=args.prefix,
+        mirrors_conf_file=args.conf_file,
+    )
+    print(f"{'UPDATED' if res.changed else 'UNCHANGED'} {res.path} in {res.file}")
+    return 0
+
+
+def cmd_gitolite_sync(args: argparse.Namespace) -> int:
+    added, pruned = sync_gitolite_from_disk(
+        base_dir=Path(args.base_dir),
+        admin_url=args.admin_url,
+        admin_dir=Path(args.admin_dir),
+        readers=args.readers,
+        prefix=args.prefix,
+        mirrors_conf_file=args.conf_file,
+        prune=bool(args.prune),
+    )
+    for p in added:
+        print(f"[ADDED] {p}")
+    for p in pruned:
+        print(f"[PRUNED] {p}")
+    if not added and not pruned:
+        print("[OK] mirrors.conf already in sync")
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="git-mirror", description="Mirror-clone and update Git repositories in a GitHub-like layout.")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    p_clone = sub.add_parser("clone", help="Mirror-clone or update a single URL")
+    p_clone.add_argument("url", help="Git URL (ssh or https)")
+    p_clone.add_argument("--base-dir", required=True, help="Base directory for mirrors")
+    p_clone.set_defaults(func=cmd_clone)
+
+    p_update = sub.add_parser("update-all", help="Fetch updates for all mirrors")
+    p_update.add_argument("--base-dir", required=True, help="Base directory for mirrors")
+    p_update.set_defaults(func=cmd_update_all)
+
+    p_list = sub.add_parser("list", help="List detected mirror repositories")
+    p_list.add_argument("--base-dir", required=True, help="Base directory for mirrors")
+    p_list.set_defaults(func=cmd_list)
+
+    p_gitolite = sub.add_parser("gitolite-add", help="Add a mirror repo ACL to gitolite-admin")
+    p_gitolite.add_argument("url", help="Upstream Git URL (ssh or https)")
+    p_gitolite.add_argument("--admin-url", required=True, help="gitolite-admin repo URL (ssh)")
+    p_gitolite.add_argument("--admin-dir", required=True, help="Local path for gitolite-admin checkout")
+    p_gitolite.add_argument("--readers", default="@all", help="Readers group or user list (default: @all)")
+    p_gitolite.add_argument("--prefix", default="mirrors", help="Path prefix inside gitolite (default: mirrors)")
+    p_gitolite.add_argument("--conf-file", default="mirrors.conf", help="Included conf filename (default: mirrors.conf)")
+    p_gitolite.set_defaults(func=cmd_gitolite_add)
+
+    p_sync = sub.add_parser("gitolite-sync", help="Ensure gitolite mirrors.conf matches on-disk mirrors")
+    p_sync.add_argument("--base-dir", required=True, help="Root folder of mirrors on disk (e.g., ~git/repositories/mirrors)")
+    p_sync.add_argument("--admin-url", required=True, help="gitolite-admin repo URL (ssh)")
+    p_sync.add_argument("--admin-dir", required=True, help="Local path to gitolite-admin checkout")
+    p_sync.add_argument("--readers", default="@all", help="Readers group or list to apply for new entries")
+    p_sync.add_argument("--prefix", default="mirrors", help="Gitolite path prefix (default: mirrors)")
+    p_sync.add_argument("--conf-file", default="mirrors.conf", help="Included conf filename (default: mirrors.conf)")
+    p_sync.add_argument("--prune", action="store_true", help="Remove config entries whose mirrors are gone on disk")
+    p_sync.set_defaults(func=cmd_gitolite_sync)
+
+    return p
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/git_mirror/core.py
+++ b/git_mirror/core.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""
+Core utilities for mirroring Git repositories into a GitHub-like folder layout.
+
+Layout:
+  <base_dir>/<host>/<owner_or_org>/<repo>.git
+
+Examples:
+  https://github.com/numpy/numpy.git  -> base/github.com/numpy/numpy.git
+  git@github.com:torvalds/linux.git   -> base/github.com/torvalds/linux.git
+  https://gitlab.com/group/sub/repo   -> base/gitlab.com/group/repo.git
+
+Notes:
+- For multi-segment namespaces (e.g. GitLab subgroups), we keep only the first
+  segment as the "owner" and the final segment as the repo, to match the
+  requested "user-or-org/repo" pattern.
+- Clones use `--mirror`. Existing mirrors are updated with `git remote update --prune`.
+"""
+
+from __future__ import annotations
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Optional, Tuple, List
+from urllib.parse import urlparse
+
+SSH_SCHEME_RE = re.compile(r"""
+    ^(?P<user>[A-Za-z0-9._-]+)@(?P<host>[A-Za-z0-9._-]+):
+    (?P<path>.+)$
+""", re.VERBOSE)
+
+
+@dataclass(frozen=True)
+class RepoID:
+    host: str
+    owner: str
+    name: str  # repo name without trailing .git
+
+    def mirror_dir(self, base_dir: Path) -> Path:
+        return base_dir / self.host / self.owner / f"{self.name}.git"
+
+
+def _strip_git_suffix(repo: str) -> str:
+    return repo[:-4] if repo.endswith(".git") else repo
+
+
+def _parse_ssh_like(url: str) -> Optional[Tuple[str, str]]:
+    """
+    Parse git@host:owner/repo(.git)? into (host, path)
+    """
+    m = SSH_SCHEME_RE.match(url)
+    if not m:
+        return None
+    return m.group("host"), m.group("path")
+
+
+def _split_owner_and_repo(path: str) -> Tuple[str, str]:
+    """
+    Convert a path like:
+      owner/repo
+      owner/sub/repo
+      /owner/repo.git
+    into ("owner", "repo") by taking the first and last components.
+    """
+    parts = [p for p in Path(path).parts if p not in ("/", "")]
+
+    # Drop common VCS prefixes if someone passes paths like "scm/repo"
+    # but we keep this minimal; the primary rule is first and last segment.
+    if len(parts) == 0:
+        raise ValueError(f"Cannot parse owner/repo from empty path: {path}")
+
+    owner = parts[0]
+    repo = _strip_git_suffix(parts[-1])
+    if repo in ("", ".", ".."):
+        raise ValueError(f"Suspicious repo segment parsed from path: {path}")
+    return owner, repo
+
+
+def parse_repo_id(url: str) -> RepoID:
+    """
+    Parse a Git URL (ssh-like or http(s)) into RepoID(host, owner, name).
+    """
+    # SSH style: git@host:owner/repo(.git)
+    ssh = _parse_ssh_like(url)
+    if ssh is not None:
+        host, path = ssh
+        owner, repo = _split_owner_and_repo(path)
+        return RepoID(host=host, owner=owner, name=repo)
+
+    # HTTP(S) style
+    parsed = urlparse(url)
+    if parsed.scheme in ("http", "https", "ssh", "git"):
+        host = parsed.hostname or ""
+        if not host:
+            raise ValueError(f"Missing host in URL: {url}")
+        # parsed.path starts with '/', remove it for clean splitting
+        owner, repo = _split_owner_and_repo(parsed.path.lstrip("/"))
+        return RepoID(host=host, owner=owner, name=repo)
+
+    # Local path fallback (less common for your use case, but harmless)
+    if os.path.exists(url):
+        # Treat local path as /owner/repo(.git), where owner is parent folder name
+        p = Path(url).resolve()
+        if p.is_dir() and p.name.endswith(".git"):
+            repo = _strip_git_suffix(p.name)
+            owner = p.parent.name or "_local"
+            return RepoID(host="_local", owner=owner, name=repo)
+        raise ValueError(f"Local path provided is not a mirror dir: {url}")
+
+    raise ValueError(f"Unsupported URL format: {url}")
+
+
+def _run(cmd: List[str], cwd: Optional[Path] = None, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        cmd,
+        cwd=str(cwd) if cwd else None,
+        check=check,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def ensure_mirror(url: str, base_dir: Path) -> Path:
+    """
+    Ensure a repository is mirror-cloned under base_dir in host/owner/repo.git.
+    If already present, do a remote update; if not, perform `git clone --mirror`.
+    Returns the path to the mirror directory.
+    """
+    rid = parse_repo_id(url)
+    target = rid.mirror_dir(base_dir)
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    if target.exists():
+        # Update existing mirror
+        _run(["git", "remote", "update", "--prune"], cwd=target)
+    else:
+        _run(["git", "clone", "--mirror", url, str(target)])
+
+    return target
+
+
+def is_git_mirror_dir(path: Path) -> bool:
+    """
+    Heuristic to detect a mirror dir: ends with .git and has typical files.
+    """
+    return (
+        path.is_dir()
+        and path.name.endswith(".git")
+        and (path / "config").exists()
+        and (path / "HEAD").exists()
+    )
+
+
+def iter_mirrored_repos(base_dir: Path) -> Iterator[Path]:
+    """
+    Yield all mirror directories under base_dir recursively.
+    """
+    if not base_dir.exists():
+        return
+    for p in base_dir.rglob("*.git"):
+        if is_git_mirror_dir(p):
+            yield p
+
+
+def fetch_mirror(repo_dir: Path) -> None:
+    """
+    Fetch updates for a single mirror repository.
+    """
+    _run(["git", "remote", "update", "--prune"], cwd=repo_dir)
+
+
+def fetch_all(base_dir: Path) -> List[Tuple[Path, Optional[str]]]:
+    """
+    Iterate all mirrored repos under base_dir and fetch updates.
+    Returns a list of tuples: (repo_path, error_message_or_None).
+    """
+    results: List[Tuple[Path, Optional[str]]] = []
+    for repo in iter_mirrored_repos(base_dir):
+        try:
+            fetch_mirror(repo)
+            results.append((repo, None))
+        except subprocess.CalledProcessError as e:
+            # Capture stderr for diagnostics, but keep going
+            err = e.stderr.strip() if e.stderr else str(e)
+            results.append((repo, err))
+    return results

--- a/git_mirror/gitolite.py
+++ b/git_mirror/gitolite.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""
+Helpers to add mirrored repositories to a Gitolite configuration.
+
+Strategy:
+- Keep all mirror ACLs in conf/mirrors.conf, included from conf/gitolite.conf.
+- Each repo gets an explicit read-only stanza, e.g.:
+
+    repo mirrors/github.com/psf/requests.git
+        R   = @all
+        RW+ =
+
+You can choose a different readers group.
+
+Typical flow:
+    ensure_admin_repo(admin_url, admin_dir)
+    ensure_include_of_mirrors_conf(admin_dir)
+    upsert_mirror_repo(admin_dir, "mirrors/github.com/psf/requests.git", readers="@all")
+    commit_and_push(admin_dir, "Add mirror: mirrors/github.com/psf/requests.git")
+
+You can build the repo path from a URL with git_mirror.core.parse_repo_id + gitolite_path_for.
+"""
+
+from __future__ import annotations
+from dataclasses import dataclass
+from pathlib import Path
+import subprocess
+import re
+from typing import Optional, List, Tuple, Dict
+import os
+
+from .core import RepoID, parse_repo_id, iter_mirrored_repos
+
+
+def _run_git(args, cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def ensure_admin_repo(admin_url: str, admin_dir: Path) -> Path:
+    """
+    Ensure a local clone of gitolite-admin exists at admin_dir.
+    If it exists, fetch & reset to origin/master (or main).
+    Returns the path.
+    """
+    admin_dir = admin_dir.resolve()
+    if not admin_dir.exists():
+        admin_dir.parent.mkdir(parents=True, exist_ok=True)
+        _run_git(["clone", admin_url, str(admin_dir)], cwd=admin_dir.parent)
+    # Refresh
+    _run_git(["fetch", "--prune", "origin"], cwd=admin_dir)
+    # Try both master and main because the world is inconsistent
+    for branch in ("master", "main"):
+        try:
+            _run_git(["rev-parse", "--verify", f"origin/{branch}"], cwd=admin_dir)
+            _run_git(["checkout", "-B", branch, f"origin/{branch}"], cwd=admin_dir)
+            break
+        except subprocess.CalledProcessError:
+            continue
+    return admin_dir
+
+
+def ensure_include_of_mirrors_conf(admin_dir: Path, include_file: str = "mirrors.conf") -> Path:
+    """
+    Ensure conf/gitolite.conf includes `include "<include_file>"`.
+    Creates conf/<include_file> if missing.
+    """
+    conf_dir = admin_dir / "conf"
+    conf_dir.mkdir(parents=True, exist_ok=True)
+    main_conf = conf_dir / "gitolite.conf"
+    mirrors_conf = conf_dir / include_file
+
+    if not main_conf.exists():
+        raise FileNotFoundError(f"{main_conf} not found. Is this a gitolite-admin repo?")
+
+    include_line = f'include "{include_file}"'
+    text = main_conf.read_text(encoding="utf-8")
+
+    if include_line not in text:
+        # add include near the end, on its own line
+        if not text.endswith("\n"):
+            text += "\n"
+        text += include_line + "\n"
+        main_conf.write_text(text, encoding="utf-8")
+
+    if not mirrors_conf.exists():
+        mirrors_conf.write_text("# Managed by git_mirror.gitolite\n", encoding="utf-8")
+
+    return mirrors_conf
+
+
+def gitolite_path_for(rid: RepoID, prefix: str = "mirrors") -> str:
+    """
+    Build the Gitolite-visible path for a mirror (matches on-disk layout).
+    Example: mirrors/github.com/psf/requests.git
+    """
+    return f"{prefix}/{rid.host}/{rid.owner}/{rid.name}.git"
+
+
+@dataclass
+class UpsertResult:
+    path: str
+    changed: bool
+    file: Path
+
+
+_STANZA_HEADER_RE = re.compile(r'^\s*repo\s+(.+?)\s*$', re.IGNORECASE)
+_READER_LINE_RE = re.compile(r'^\s*R\s*=\s*(.+?)\s*$', re.IGNORECASE)
+
+
+def upsert_mirror_repo(
+    admin_dir: Path,
+    repo_path: str,
+    readers: str = "@all",
+    mirrors_conf_file: str = "mirrors.conf",
+) -> UpsertResult:
+    """
+    Ensure a read-only stanza for `repo_path` exists in conf/<mirrors_conf_file>.
+    Returns UpsertResult(changed=bool).
+    """
+    mirrors_conf = admin_dir / "conf" / mirrors_conf_file
+    if not mirrors_conf.exists():
+        raise FileNotFoundError(f"{mirrors_conf} does not exist; call ensure_include_of_mirrors_conf first.")
+
+    content = mirrors_conf.read_text(encoding="utf-8").splitlines()
+
+    # Find existing stanza indices if present
+    i = 0
+    start_idx = end_idx = None
+    while i < len(content):
+        m = _STANZA_HEADER_RE.match(content[i])
+        if m:
+            current_repo = m.group(1).strip()
+            # stanza ends before next 'repo ' header or file end
+            j = i + 1
+            while j < len(content) and not _STANZA_HEADER_RE.match(content[j]):
+                j += 1
+            if current_repo == repo_path:
+                start_idx, end_idx = i, j
+                break
+            i = j
+        else:
+            i += 1
+
+    desired = [
+        f"repo {repo_path}",
+        f"    R   = {readers}",
+        "    RW+ =",
+        "",
+    ]
+
+    if start_idx is None:
+        # Append new stanza
+        if content and content[-1].strip() != "":
+            content.append("")  # ensure blank line before new stanza
+        content.extend(desired)
+        mirrors_conf.write_text("\n".join(content) + "\n", encoding="utf-8")
+        return UpsertResult(path=repo_path, changed=True, file=mirrors_conf)
+
+    # Update existing stanza minimally: ensure readers line is correct and RW+ is empty
+    stanza = content[start_idx:end_idx]
+    updated = False
+
+    # Ensure R line
+    has_r = False
+    for k, line in enumerate(stanza):
+        if _READER_LINE_RE.match(line):
+            has_r = True
+            new_line = f"    R   = {readers}"
+            if line.strip() != new_line.strip():
+                stanza[k] = new_line
+                updated = True
+            break
+    if not has_r:
+        stanza.insert(1, f"    R   = {readers}")
+        updated = True
+
+    # Ensure RW+ present and empty
+    if not any(l.strip().lower().startswith("rw+") for l in stanza):
+        stanza.insert(2, "    RW+ =")
+        updated = True
+    else:
+        stanza = [
+            ("    RW+ =" if l.strip().lower().startswith("rw+") else l)
+            for l in stanza
+        ]
+
+    if updated:
+        # write back merged content
+        content = content[:start_idx] + stanza + content[end_idx:]
+        mirrors_conf.write_text("\n".join(content) + "\n", encoding="utf-8")
+
+    return UpsertResult(path=repo_path, changed=updated, file=mirrors_conf)
+
+
+def commit_and_push(admin_dir: Path, message: str) -> None:
+    """
+    Commit any pending changes in the admin repo and push.
+    No-op if there are no changes.
+    """
+    # Stage everything under conf/
+    _run_git(["add", "conf"], cwd=admin_dir)
+
+    # If nothing to commit, short-circuit
+    status = _run_git(["status", "--porcelain"], cwd=admin_dir).stdout.strip()
+    if not status:
+        return
+
+    _run_git(["commit", "-m", message], cwd=admin_dir)
+    _run_git(["push", "origin", "HEAD"], cwd=admin_dir)
+
+
+def add_url_to_gitolite(
+    url: str,
+    admin_url: str,
+    admin_dir: Path,
+    *,
+    readers: str = "@all",
+    prefix: str = "mirrors",
+    mirrors_conf_file: str = "mirrors.conf",
+) -> UpsertResult:
+    """
+    One-shot convenience: given an upstream URL, add its mirror path to Gitolite config.
+    - Clones/refreshes gitolite-admin
+    - Ensures include of mirrors.conf
+    - Upserts the repo stanza
+    - Commits and pushes (only if changes)
+    """
+    rid = parse_repo_id(url)
+    repo_path = gitolite_path_for(rid, prefix=prefix)
+
+    ensure_admin_repo(admin_url, admin_dir)
+    ensure_include_of_mirrors_conf(admin_dir, include_file=mirrors_conf_file)
+    res = upsert_mirror_repo(admin_dir, repo_path, readers=readers, mirrors_conf_file=mirrors_conf_file)
+    if res.changed:
+        commit_and_push(admin_dir, f"Add mirror: {repo_path}")
+    return res
+
+
+# ---------- helpers to read/write mirrors.conf ----------
+
+def _mirrors_conf_path(admin_dir: Path, mirrors_conf_file: str) -> Path:
+    p = admin_dir / "conf" / mirrors_conf_file
+    if not p.exists():
+        raise FileNotFoundError(f"{p} does not exist; run ensure_include_of_mirrors_conf() first.")
+    return p
+
+
+def parse_mirrors_conf(admin_dir: Path, mirrors_conf_file: str = "mirrors.conf") -> Dict[str, Tuple[int, int]]:
+    """
+    Parse conf/<mirrors_conf_file> and return a map:
+        repo_path -> (start_index, end_index)
+    Indices are line ranges [start, end) for the stanza.
+    """
+    mirrors_conf = _mirrors_conf_path(admin_dir, mirrors_conf_file)
+    lines = mirrors_conf.read_text(encoding="utf-8").splitlines()
+    pos: Dict[str, Tuple[int, int]] = {}
+
+    i = 0
+    while i < len(lines):
+        m = _STANZA_HEADER_RE.match(lines[i])
+        if not m:
+            i += 1
+            continue
+        repo = m.group(1).strip()
+        j = i + 1
+        while j < len(lines) and not _STANZA_HEADER_RE.match(lines[j]):
+            j += 1
+        pos[repo] = (i, j)
+        i = j
+    return pos
+
+
+def configured_mirror_paths(admin_dir: Path, mirrors_conf_file: str = "mirrors.conf") -> List[str]:
+    """
+    Return a list of 'repo <path>' entries currently configured in mirrors.conf.
+    """
+    return sorted(parse_mirrors_conf(admin_dir, mirrors_conf_file).keys())
+
+
+def gitolite_path_from_mirror_dir(base_dir: Path, repo_dir: Path, prefix: str = "mirrors") -> str:
+    """
+    Convert an on-disk mirror path into the Gitolite path.
+    Example:
+        base_dir=/home/git/repositories/mirrors
+        repo_dir=/home/git/repositories/mirrors/github.com/psf/requests.git
+        -> mirrors/github.com/psf/requests.git
+    """
+    base_dir = base_dir.resolve()
+    repo_dir = repo_dir.resolve()
+    rel = repo_dir.relative_to(base_dir)  # raises if not under base_dir
+    # Ensure .git suffix is present in the Gitolite path
+    name = rel.name if rel.name.endswith(".git") else f"{rel.name}.git"
+    rel = rel.with_name(name)
+    return str(Path(prefix) / rel)
+
+
+def sync_gitolite_from_disk(
+    base_dir: Path,
+    admin_url: str,
+    admin_dir: Path,
+    *,
+    readers: str = "@all",
+    prefix: str = "mirrors",
+    mirrors_conf_file: str = "mirrors.conf",
+    prune: bool = False,
+) -> Tuple[List[str], List[str]]:
+    """
+    Ensure every on-disk mirror under base_dir has a corresponding read-only
+    entry in gitolite's mirrors.conf. Optionally prune stanzas whose mirrors
+    no longer exist on disk.
+
+    Returns (added_paths, pruned_paths).
+    """
+    ensure_admin_repo(admin_url, admin_dir)
+    ensure_include_of_mirrors_conf(admin_dir, include_file=mirrors_conf_file)
+
+    # Build sets
+    disk_paths: List[str] = []
+    for repo in iter_mirrored_repos(base_dir):
+        try:
+            disk_paths.append(gitolite_path_from_mirror_dir(base_dir, repo, prefix=prefix))
+        except Exception:
+            # Skip anything weird that's not under base_dir
+            continue
+    set_disk = set(disk_paths)
+    set_cfg = set(configured_mirror_paths(admin_dir, mirrors_conf_file))
+
+    to_add = sorted(set_disk - set_cfg)
+    to_prune = sorted(set_cfg - set_disk) if prune else []
+
+    # Add missing
+    changed = False
+    added: List[str] = []
+    for path in to_add:
+        res = upsert_mirror_repo(admin_dir, path, readers=readers, mirrors_conf_file=mirrors_conf_file)
+        if res.changed:
+            changed = True
+        added.append(path)
+
+    # Prune stale stanzas
+    pruned: List[str] = []
+    if to_prune:
+        mirrors_conf = _mirrors_conf_path(admin_dir, mirrors_conf_file)
+        lines = mirrors_conf.read_text(encoding="utf-8").splitlines()
+        spans = parse_mirrors_conf(admin_dir, mirrors_conf_file)
+
+        # Remove from bottom to top so indices stay valid
+        for repo in sorted(to_prune, key=lambda r: spans[r][0], reverse=True):
+            si, sj = spans[repo]
+            del lines[si:sj]
+            # Trim surrounding blank lines
+            while si < len(lines) and lines[si].strip() == "":
+                del lines[si]
+            changed = True
+            pruned.append(repo)
+
+        mirrors_conf.write_text("\n".join(lines) + ("\n" if lines and lines[-1] != "" else ""), encoding="utf-8")
+
+    if changed:
+        commit_and_push(admin_dir, "Sync mirrors.conf with on-disk mirrors")
+
+    return added, pruned

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "git-mirror"
+version = "0.1.0"
+description = "Utility to mirror Git repositories and integrate with Gitolite"
+readme = "README.md"
+requires-python = ">=3.8"
+
+[project.scripts]
+git-mirror = "git_mirror.cli:main"


### PR DESCRIPTION
## Summary
- implement core mirroring functions and helpers
- add Gitolite configuration management and syncing
- expose CLI to mirror, update, list, and sync repositories
- clean up repository by removing Python cache files and ignoring them

## Testing
- `python -m git_mirror.cli --help`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b618a33bb4832293b801c118393e41