### PR TITLE
Add status command and sync tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,27 +8,52 @@ Git repo mirroring command line utility.
 - Update all mirrored repositories with a single command.
 - Integrate with Gitolite by adding and syncing mirror entries in `gitolite-admin`.
 
-## Usage
+## Command line usage
 
-Run the commands via the module:
+Invoke the CLI via the module:
 
 ```bash
 python -m git_mirror.cli --help
 ```
 
-To mirror a repository:
+### `clone`
+Mirror-clone (or update) a single repository.
+
+```
+python -m git_mirror.cli clone <url> --base-dir <path>
+```
+Example:
 
 ```bash
 python -m git_mirror.cli clone https://github.com/psf/requests.git --base-dir /srv/git
 ```
 
-To update all mirrors:
+### `update-all`
+Fetch updates for every mirror under `--base-dir` and record the last sync time.
+
+```
+python -m git_mirror.cli update-all --base-dir <path>
+```
+Example:
 
 ```bash
 python -m git_mirror.cli update-all --base-dir /srv/git
 ```
 
-To add the mirror to Gitolite:
+### `list`
+List all detected mirror repositories.
+
+```
+python -m git_mirror.cli list --base-dir <path>
+```
+
+### `gitolite-add`
+Add or update a mirror entry in `gitolite-admin`.
+
+```
+python -m git_mirror.cli gitolite-add <url> --admin-url <ssh-url> --admin-dir <path> [--readers @all] [--prefix mirrors] [--conf-file mirrors.conf]
+```
+Example:
 
 ```bash
 python -m git_mirror.cli gitolite-add https://github.com/psf/requests.git \
@@ -36,10 +61,30 @@ python -m git_mirror.cli gitolite-add https://github.com/psf/requests.git \
   --admin-dir /home/git/gitolite-admin
 ```
 
-To ensure the Gitolite configuration matches on-disk mirrors:
+### `gitolite-sync`
+Ensure the Gitolite configuration matches on-disk mirrors. Pass `--prune` to remove stale entries.
+
+```
+python -m git_mirror.cli gitolite-sync --base-dir <path> --admin-url <ssh-url> --admin-dir <path> [--readers @all] [--prefix mirrors] [--conf-file mirrors.conf] [--prune]
+```
+Example:
 
 ```bash
 python -m git_mirror.cli gitolite-sync --base-dir /srv/git \
+  --admin-url git@yourhost:gitolite-admin \
+  --admin-dir /home/git/gitolite-admin
+```
+
+### `status`
+Report on the state of mirror folders and Gitolite configuration. Shows layout problems, mirrors missing from the config, config entries without a mirror, and the last recorded sync time.
+
+```
+python -m git_mirror.cli status --base-dir <path> --admin-url <ssh-url> --admin-dir <path> [--prefix mirrors] [--conf-file mirrors.conf]
+```
+Example:
+
+```bash
+python -m git_mirror.cli status --base-dir /srv/git \
   --admin-url git@yourhost:gitolite-admin \
   --admin-dir /home/git/gitolite-admin
 ```

--- a/git_mirror/__init__.py
+++ b/git_mirror/__init__.py
@@ -5,6 +5,8 @@ from .core import (
     iter_mirrored_repos,
     fetch_mirror,
     fetch_all,
+    record_sync_time,
+    read_sync_time,
 )
 
 from .gitolite import (
@@ -18,4 +20,5 @@ from .gitolite import (
     configured_mirror_paths,
     gitolite_path_from_mirror_dir,
     sync_gitolite_from_disk,
+    status_report,
 )

--- a/git_mirror/core.py
+++ b/git_mirror/core.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator, Optional, Tuple, List
 from urllib.parse import urlparse
+from datetime import datetime
 
 SSH_SCHEME_RE = re.compile(r"""
     ^(?P<user>[A-Za-z0-9._-]+)@(?P<host>[A-Za-z0-9._-]+):
@@ -188,3 +189,20 @@ def fetch_all(base_dir: Path) -> List[Tuple[Path, Optional[str]]]:
             err = e.stderr.strip() if e.stderr else str(e)
             results.append((repo, err))
     return results
+
+
+SYNC_MARKER = ".last_sync"
+
+
+def record_sync_time(base_dir: Path) -> None:
+    base_dir = base_dir.resolve()
+    base_dir.mkdir(parents=True, exist_ok=True)
+    marker = base_dir / SYNC_MARKER
+    marker.write_text(datetime.utcnow().isoformat() + "\n", encoding="utf-8")
+
+
+def read_sync_time(base_dir: Path) -> Optional[str]:
+    marker = base_dir / SYNC_MARKER
+    if marker.exists():
+        return marker.read_text(encoding="utf-8").strip()
+    return None


### PR DESCRIPTION
## Summary
- track last sync time for mirror directories
- add `status` subcommand to compare mirrors with gitolite config
- document CLI commands and arguments with examples

## Testing
- `python -m git_mirror.cli --help`
- `python -m git_mirror.cli status --help`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b622403cb88322897f81ad28f986d7