### PR TITLE
Add persistent configuration for git-mirror CLI

### DIFF
--- a/.git-mirror.conf
+++ b/.git-mirror.conf
@@ -1,0 +1,7 @@
+[git-mirror]
+# Configuration defaults for git-mirror CLI
+# admin-url = git@host:gitolite-admin
+# admin-dir = /path/to/gitolite-admin
+readers = @all
+prefix = mirrors
+conf-file = mirrors.conf

--- a/git_mirror/config.py
+++ b/git_mirror/config.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from configparser import ConfigParser
+from pathlib import Path
+from typing import Optional
+
+CONFIG_FILENAME = ".git-mirror.conf"
+SECTION = "git-mirror"
+
+def config_path(base_dir: Path) -> Path:
+    """Return the path to the config file inside *base_dir*."""
+    return base_dir / CONFIG_FILENAME
+
+def load_config(base_dir: Path) -> ConfigParser:
+    """Load configuration from *base_dir*.
+
+    If the file does not exist an empty ConfigParser is returned.
+    """
+    cfg = ConfigParser()
+    path = config_path(base_dir)
+    if path.exists():
+        cfg.read(path)
+    return cfg
+
+def save_config(base_dir: Path, cfg: ConfigParser) -> None:
+    """Persist *cfg* in *base_dir*."""
+    path = config_path(base_dir)
+    with path.open("w") as fh:
+        cfg.write(fh)
+
+def get_value(base_dir: Path, key: str, default: Optional[str] = None) -> Optional[str]:
+    """Return the value for *key* from config under *base_dir*."""
+    cfg = load_config(base_dir)
+    if cfg.has_option(SECTION, key):
+        return cfg.get(SECTION, key)
+    return default
+
+def set_value(base_dir: Path, key: str, value: str) -> None:
+    """Set *key* to *value* in config under *base_dir*."""
+    cfg = load_config(base_dir)
+    if not cfg.has_section(SECTION):
+        cfg.add_section(SECTION)
+    cfg.set(SECTION, key, value)
+    save_config(base_dir, cfg)
+
+def find_base_dir(start: Optional[Path] = None) -> Optional[Path]:
+    """Search upwards from *start* (or CWD) for the config file.
+
+    Returns the directory containing the config, or ``None`` if not found.
+    """
+    current = start or Path.cwd()
+    for path in [current, *current.parents]:
+        if (path / CONFIG_FILENAME).exists():
+            return path
+    return None


### PR DESCRIPTION
## Summary
- support storing default git-mirror options in a config file
- add `.git-mirror.conf` sample configuration
- introduce `git-mirror config` command and automatic default loading

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b624318e2483229d1f5792d246b99d