### PR TITLE
Add shell completion script generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,20 @@ python -m git_mirror.cli status --base-dir /srv/git \
   --admin-dir /home/git/gitolite-admin
 ```
 
+### `completion`
+Generate a shell completion script for Bash or Zsh. Evaluate the output to enable
+tab completion in the current shell session.
+
+```
+python -m git_mirror.cli completion [--prog git-mirror]
+```
+Example:
+
+```bash
+eval "$(python -m git_mirror.cli completion)"
+```
+Requires `argcomplete` to be installed.
+
 ## System integration
 
 Example systemd units are provided in `examples/systemd`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,5 +5,8 @@ description = "Utility to mirror Git repositories and integrate with Gitolite"
 readme = "README.md"
 requires-python = ">=3.8"
 
+[project.optional-dependencies]
+completion = ["argcomplete"]
+
 [project.scripts]
 git-mirror = "git_mirror.cli:main"


### PR DESCRIPTION
## Summary
- add argcomplete-powered `completion` subcommand to generate bash/zsh completion scripts
- document shell completion usage
- expose optional `argcomplete` dependency

## Testing
- `python -m git_mirror.cli --help | head -n 40`
- `python -m git_mirror.cli completion | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b625b3169c8322a2603c65376664b8