### PR TITLE
Preserve full repository path when mirroring

### DIFF
--- a/git_mirror/gitolite.py
+++ b/git_mirror/gitolite.py
@@ -98,9 +98,9 @@ def ensure_include_of_mirrors_conf(admin_dir: Path, include_file: str = "mirrors
 def gitolite_path_for(rid: RepoID, prefix: str = "mirrors") -> str:
     """
     Build the Gitolite-visible path for a mirror (matches on-disk layout).
-    Example: mirrors/github.com/psf/requests.git
+    Example: mirrors/github.com/psf/requests.git or mirrors/gitlab.com/group/sub/repo.git
     """
-    return f"{prefix}/{rid.host}/{rid.owner}/{rid.name}.git"
+    return f"{prefix}/{rid.host}/{'/'.join(rid.path)}.git"
 
 
 @dataclass

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from git_mirror.core import parse_repo_id
+from git_mirror.gitolite import gitolite_path_for
+
+
+def test_parse_repo_id_preserves_full_path(tmp_path: Path) -> None:
+    url = "https://gitlab.com/group/sub/repo.git"
+    rid = parse_repo_id(url)
+    assert rid.host == "gitlab.com"
+    assert rid.path == ("group", "sub", "repo")
+    assert rid.owner == "group"
+    assert rid.name == "repo"
+    expected = tmp_path / "gitlab.com" / "group" / "sub" / "repo.git"
+    assert rid.mirror_dir(tmp_path) == expected
+    assert gitolite_path_for(rid) == "mirrors/gitlab.com/group/sub/repo.git"


### PR DESCRIPTION
## Summary
- store mirrors using the complete path after the host
- extend RepoID to track all path segments and update gitolite path helper
- add regression test for nested repository paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b62beaf10c8322a43b08f7f2db6ac4