### PR TITLE
Allow status without gitolite and add systemd service registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ sudo systemctl daemon-reload
 sudo systemctl enable --now git-mirror.timer
 ```
 
+To install a user-level systemd timer instead, run:
+
+```bash
+python -m git_mirror.cli register-service --base-dir /home/git/repositories/mirrors
+```
+
+If `--base-dir` is omitted, the current directory is used when it contains `.git-mirror.conf`.
+
 ## Gitolite configuration
 
 Sample Gitolite configuration files live in `examples/gitolite`.

--- a/examples/systemd/register-user-service.sh
+++ b/examples/systemd/register-user-service.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Register a user-level git-mirror service and timer
+# Replace /home/git/repositories/mirrors with your base directory
+python -m git_mirror.cli register-service --base-dir /home/git/repositories/mirrors

--- a/git_mirror/systemd.py
+++ b/git_mirror/systemd.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Tuple
+
+SERVICE_TEMPLATE = """[Unit]
+Description=Mirror and sync Gitolite ACLs for {base}
+
+[Service]
+Type=oneshot
+WorkingDirectory={base}
+ExecStart={python} -m git_mirror.cli update-all --base-dir {base}
+ExecStart={python} -m git_mirror.cli gitolite-sync --base-dir {base}
+
+[Install]
+WantedBy=default.target
+"""
+
+TIMER_TEMPLATE = """[Unit]
+Description=Run git-mirror for {base} periodically
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=15min
+Unit={unit}
+
+[Install]
+WantedBy=timers.target
+"""
+
+
+def _unit_name(base: Path) -> str:
+    slug = base.resolve().as_posix().replace('/', '-').lstrip('-')
+    return f"git-mirror-{slug}.service"
+
+
+def register_user_service(base: Path) -> Tuple[Path, Path]:
+    """Create and enable user-level systemd service and timer for *base*.
+
+    Returns (service_path, timer_path).
+    """
+    unit = _unit_name(base)
+    timer = unit.replace('.service', '.timer')
+    user_dir = Path.home() / '.config' / 'systemd' / 'user'
+    user_dir.mkdir(parents=True, exist_ok=True)
+    service_path = user_dir / unit
+    timer_path = user_dir / timer
+    python = sys.executable
+    service_path.write_text(
+        SERVICE_TEMPLATE.format(base=base, python=python), encoding='utf-8'
+    )
+    timer_path.write_text(
+        TIMER_TEMPLATE.format(base=base, unit=unit), encoding='utf-8'
+    )
+    subprocess.run(['systemctl', '--user', 'daemon-reload'], check=True)
+    subprocess.run(['systemctl', '--user', 'enable', '--now', timer], check=True)
+    return service_path, timer_path


### PR DESCRIPTION
## Summary
- allow `status` to run without gitolite details by skipping config checks when none supplied
- add `register-service` command to install a user systemd service and timer for a mirror base directory
- document the new command and provide an example script

## Testing
- `python -m git_mirror.cli status --base-dir .`
- `python -m git_mirror.cli completion --prog git-mirror`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b63c105ae88322bc1472932548caf4